### PR TITLE
Feat: 이메일 중복 에러 확인

### DIFF
--- a/scripts/signin.js
+++ b/scripts/signin.js
@@ -168,7 +168,7 @@ signInBtnEl.addEventListener('click', (e) => {
                 const errorCode = error.code;
                 const errorMessage = error.message;
 
-                if (EMAIL_DUPLICATE_CODE) {
+                if (errorCode === EMAIL_DUPLICATE_CODE) {
                     alert('중복된 이메일이 존재합니다.');
                     inputEmailEl.classList.add('error');
                     emailMsgEl.innerText = '중복된 이메일이 존재합니다.';

--- a/scripts/signin.js
+++ b/scripts/signin.js
@@ -160,10 +160,19 @@ signInBtnEl.addEventListener('click', (e) => {
         )
             .then((userCredential) => {
                 const user = userCredential.user;
+                alert('회원가입이 완료되었습니다.');
+                window.location.href = './login.html';
             })
             .catch((error) => {
+                const EMAIL_DUPLICATE_CODE = 'auth/email-already-in-use';
                 const errorCode = error.code;
                 const errorMessage = error.message;
+
+                if (EMAIL_DUPLICATE_CODE) {
+                    alert('중복된 이메일이 존재합니다.');
+                    inputEmailEl.classList.add('error');
+                    emailMsgEl.innerText = '중복된 이메일이 존재합니다.';
+                }
             });
     }
     checkEmailValidation(inputEmailEl.value);

--- a/scripts/signin.js
+++ b/scripts/signin.js
@@ -164,11 +164,11 @@ signInBtnEl.addEventListener('click', (e) => {
                 window.location.href = './login.html';
             })
             .catch((error) => {
-                const EMAIL_DUPLICATE_CODE = 'auth/email-already-in-use';
+                const EMAIL_DUPLICATE_ERROR_CODE = 'auth/email-already-in-use';
                 const errorCode = error.code;
                 const errorMessage = error.message;
 
-                if (errorCode === EMAIL_DUPLICATE_CODE) {
+                if (errorCode === EMAIL_DUPLICATE_ERROR_CODE) {
                     alert('중복된 이메일이 존재합니다.');
                     inputEmailEl.classList.add('error');
                     emailMsgEl.innerText = '중복된 이메일이 존재합니다.';


### PR DESCRIPTION
## 작업 내용
회원가입 기능 구현하기

## 유효성 검사 로직
이메일, 이름, 비밀번호, 비밀번호 확인 필드에 대한 유효성 검사를 수행

### 유효성 검사 시점
* input `focus out`시 해당 필드의 유효성 검사
* 회원가입 버튼 클릭 시 모든 필드의 유효성 검사

### 유효성 검사 패턴
모든 필드의 값은 빠짐없이 입력해야합니다.
이메일, 이름, 비밀번호, 비밀번호 확인 필드는 해당 조건의 유효성 조건을 통과해야합니다.

* 이메일: 이메일 형식
* 이름: 한글과 영문 사용 가능
* 비밀번호: 8~16자 영문 소/대문자, 숫자 사용가능
* 비밀번호 확인: 비밀번호와 일치

### 커스텀 에러 메세지
유효하지 않은 값일 경우, 각 에러에 맞는 에러 메세지를 보여주어야 합니다.

* (공통) 빈 값일 경우: "필수 정보입니다."
* (이메일) 유효하지 않은 값일 경우: "이메일 형식을 맞춰서 입력해주세요."
* (이름) 유효하지 않은 값일 경우: "이름 형식이 올바르지 않습니다."
* (비밀번호) 유효하지 않은 값일 경우: "8~16자 영문 소/대문자, 숫자를 사용하세요."
* (비밀번호 확인) 유효하지 않은 값일 경우: "비밀번호가 일치하지 않습니다."

### 이 외 수정 사항
* 이메일 등록시 alert로 회원가입이 완료되었음을 알리고 로그인 페이지로 이동
* 이메일 중복 시 중복되었음을 알리고 이메일 input error 메세지 출력


## 완료 예상일
2023.08.31

## 하위 태스크
- [x] 이메일 유효성 검사
- [x] 비밀번호 유효성 검사
- [x] 이메일 유효성 검사
- [x] 페이지 접속시 이메일 오토포커스
- [ ] 리팩토링